### PR TITLE
Allow configuring client certificate and key via user configurations

### DIFF
--- a/scripts/arcanist.php
+++ b/scripts/arcanist.php
@@ -281,6 +281,25 @@ try {
     HTTPSFuture::setGlobalCABundleFromPath($ca_bundle);
   }
 
+  // Apply global user cert from configs.
+  $user_cert = $configuration_manager->getConfigFromAnySource(
+    'https.user-cert');
+  if ($user_cert) {
+    $user_cert = Filesystem::resolvePath(
+      $user_cert, $working_copy->getProjectRoot());
+      HTTPSFuture::setGlobalUserCertFromPath($user_cert);
+
+    // Certificate key is optional if the certificate PEM file already contains
+    // the private key
+    $user_key = $configuration_manager->getConfigFromAnySource(
+      'https.user-key');
+    if ($user_key) {
+      $user_key = Filesystem::resolvePath(
+        $user_key, $working_copy->getProjectRoot());
+      HTTPSFuture::setGlobalUserCertKeyFromPath($user_key);
+    }
+  }
+
   $blind_key = 'https.blindly-trust-domains';
   $blind_trust = $configuration_manager->getConfigFromAnySource($blind_key);
   if ($blind_trust) {

--- a/src/configuration/ArcanistSettings.php
+++ b/src/configuration/ArcanistSettings.php
@@ -136,7 +136,7 @@ final class ArcanistSettings extends Phobject {
           "To be used alongside https.user-cert. This is used primarily ".
           "when your conduit endpoint is behind HTTPS with client certificate ".
           "verification enabled."),
-        'example' => 'support/yourca.key',
+        'example' => 'support/yourkey.key',
       ),
       'https.blindly-trust-domains' => array(
         'type' => 'list',

--- a/src/configuration/ArcanistSettings.php
+++ b/src/configuration/ArcanistSettings.php
@@ -121,6 +121,23 @@ final class ArcanistSettings extends Phobject {
           "behind HTTPS signed by your organization's internal CA."),
         'example' => 'support/yourca.pem',
       ),
+      'https.user-cert' => array(
+        'type' => 'string',
+        'help' => pht(
+          "Path to a PEM certificate file to be used for arcanist's cURL ".
+          "calls. This is used primarily when your conduit endpoint is ".
+          "behind HTTPS with client certificate verification enabled."),
+        'example' => 'support/yourcert.pem',
+      ),
+      'https.user-key' => array(
+        'type' => 'string',
+        'help' => pht(
+          "Path to a private key file to be used for arcanist's cURL calls. ".
+          "To be used alongside https.user-cert. This is used primarily ".
+          "when your conduit endpoint is behind HTTPS with client certificate ".
+          "verification enabled."),
+        'example' => 'support/yourca.key',
+      ),
       'https.blindly-trust-domains' => array(
         'type' => 'list',
         'help' => pht(


### PR DESCRIPTION
Client certificate and key can be configured via

```console
$  ./bin/arc set-config https.user-cert "$PKI_CERT"
Set key "https.user-cert" = "/home/isattvika/.certs/certs/member/putrasattvika@55c24dc7e78149b0b4ab028a144c1c9c@pkictl-prod/putrasattvika@55c24dc7e78149b0b4ab028a144c1c9c@pkictl-prod.crt" in user config (was null).

$ ./bin/arc set-config https.user-key "$PKI_KEY" 
Set key "https.user-key" = "/home/isattvika/.certs/certs/member/putrasattvika@55c24dc7e78149b0b4ab028a144c1c9c@pkictl-prod/.private/putrasattvika@55c24dc7e78149b0b4ab028a144c1c9c@pkictl-prod.key" in user config (was null).
```

```console
$ ./bin/arc get-config https.user-cert --verbose
https.user-cert

    Path to a PEM certificate file to be used for arcanist's cURL calls. This
    is used primarily when your conduit endpoint is behind HTTPS with client
    certificate verification enabled.

       Example Value: support/yourcert.pem

       Current Value: "/home/isattvika/.certs/certs/member/putrasattvika@55c24dc7e78149b0b4ab028a144c1c9c@pkictl-prod/putrasattvika@55c24dc7e78149b0b4ab028a144c1c9c@pkictl-prod.crt"
      Current Source: user

         local Value: -
       project Value: -
          user Value: "/home/isattvika/.certs/certs/member/putrasattvika@55c24dc7e78149b0b4ab028a144c1c9c@pkictl-prod/putrasattvika@55c24dc7e78149b0b4ab028a144c1c9c@pkictl-prod.crt"
        system Value: -
       default Value: -

$ ./bin/arc get-config https.user-key --verbose   
https.user-key

    Path to a private key file to be used for arcanist's cURL calls. To be
    used alongside https.user-cert. This is used primarily when your conduit
    endpoint is behind HTTPS with client certificate verification enabled.

       Example Value: support/yourkey.key

       Current Value: "/home/isattvika/.certs/certs/member/putrasattvika@55c24dc7e78149b0b4ab028a144c1c9c@pkictl-prod/.private/putrasattvika@55c24dc7e78149b0b4ab028a144c1c9c@pkictl-prod.key"
      Current Source: user

         local Value: -
       project Value: -
          user Value: "/home/isattvika/.certs/certs/member/putrasattvika@55c24dc7e78149b0b4ab028a144c1c9c@pkictl-prod/.private/putrasattvika@55c24dc7e78149b0b4ab028a144c1c9c@pkictl-prod.key"
        system Value: -
       default Value: -
```